### PR TITLE
Add support for https.

### DIFF
--- a/lib/mixpanel-node.js
+++ b/lib/mixpanel-node.js
@@ -8,6 +8,7 @@
 */
 
 var http            = require('http'),
+    https           = require('https'),
     querystring     = require('querystring'),
     Buffer          = require('buffer').Buffer,
     util            = require('util');
@@ -24,7 +25,8 @@ var create_client = function(token, config) {
         test: false,
         debug: false,
         verbose: false,
-        host: 'api.mixpanel.com'
+        host: 'api.mixpanel.com',
+        protocol: 'http'
     };
 
     metrics.token = token;
@@ -47,6 +49,8 @@ var create_client = function(token, config) {
             'verbose': metrics.config.verbose ? 1 : 0
         };
 
+        var protocol = metrics.config.protocol === 'http' ? http : https;
+
         if (endpoint === '/import') {
             var key = metrics.config.key;
             if (!key) {
@@ -67,7 +71,7 @@ var create_client = function(token, config) {
 
         request_options.path = [endpoint,"?",query].join("");
 
-        http.get(request_options, function(res) {
+        protocol.get(request_options, function(res) {
             var data = "";
             res.on('data', function(chunk) {
                data += chunk;

--- a/test/config.js
+++ b/test/config.js
@@ -8,7 +8,7 @@ exports.config = {
 
     "is set to correct defaults": function(test) {
         test.deepEqual(this.mixpanel.config,
-                       { test: false, debug: false, verbose: false, host: 'api.mixpanel.com' },
+                       { test: false, debug: false, verbose: false, host: 'api.mixpanel.com', protocol: 'http' },
                        "default config is incorrect");
         test.done();
     },


### PR DESCRIPTION
In order to use https as the protocol:
```
var mixpanel = Mixpanel.init('6fd9434dba686db2d1ab66b4462a3a67', { protocol: 'https' });
```